### PR TITLE
feat(rbac): Implementar autorización multi-rol para gestión de usuarios

### DIFF
--- a/src/config/const.js
+++ b/src/config/const.js
@@ -1,0 +1,6 @@
+export const USER_ROLES = [
+    'admin', 
+    'profesor', 
+    'secretaria', 
+    'alumno' 
+];

--- a/src/middleware/authorize.role.js
+++ b/src/middleware/authorize.role.js
@@ -1,0 +1,27 @@
+/**
+ * Middleware de fábrica que retorna una función que valida el rol del usuario en el token.
+ * NOTA: Este middleware debe ejecutarse DESPUÉS de verifyToken.
+ * @param {string[] | string} requiredRoles - El rol o un array de roles requeridos.
+ */
+export const authorizeRole = (requiredRoles) => (req, res, next) => {
+    // 1. Unificamos a un array, incluso si solo se pasó un string.
+    const rolesArray = Array.isArray(requiredRoles) ? requiredRoles : [requiredRoles];
+    
+    // El rol viene del payload del JWT adjuntado por verifyToken
+    const userRole = req.user.rol; 
+
+    // 2. Verificación del rol
+    if (!userRole) {
+        return res.status(403).json({ message: 'No se encontró el rol del usuario en el token.' });
+    }
+
+    // 3. Comprobación CRÍTICA: Verifica si el rol del usuario está incluido en la lista de roles permitidos.
+    if (!rolesArray.includes(userRole)) {
+        // 403 Forbidden: El usuario no tiene el rol correcto.
+        const requiredString = rolesArray.join(' o ');
+        return res.status(403).json({ message: `Acceso denegado. Se requiere uno de estos roles: ${requiredString}.` });
+    }
+
+    // Acceso permitido
+    next();
+};

--- a/src/middleware/authorize.user.js
+++ b/src/middleware/authorize.user.js
@@ -1,20 +1,14 @@
 
-// La función verifyToken debe ejecutarse ANTES de esta, para asegurar que req.user exista.
+
 export const authorizeUser = async (req, res, next) => {
     try {
-        // 1. Obtener el ID del usuario autenticado del JWT (adjuntado por verifyToken)
-        const userIdFromToken = req.user.id.toString(); 
-        
-        // 2. Obtener el ID del recurso que se intenta modificar (de la URL)
-        const resourceId = req.params.id; 
+        const userIdFromToken = req.user.id.toString();
+        const resourceId = req.params.id;
+        const userRole = req.user.rol;
 
-        // 3. Obtener el ROL del usuario (también del JWT)
-        const userRole = req.user.rol; 
-
-        // Validamos la existencia del ID del token y del recurso
         if (!userIdFromToken || !resourceId) {
-             // Este error indica un problema en el flujo, ya que verifyToken debe garantizar userIdFromToken.
-             return res.status(500).json({ message: "Error interno: Identidad no disponible en la solicitud." });
+
+            return res.status(500).json({ message: "Error interno: Identidad no disponible en la solicitud." });
         }
 
         //LÓGICA DE AUTORIZACIÓN (El corazón del middleware)
@@ -31,7 +25,7 @@ export const authorizeUser = async (req, res, next) => {
         if (userIdFromToken !== resourceId) {
             return res.status(403).json({ message: "Acceso prohibido. No tienes permiso para modificar este recurso." });
         }
-        
+
         // C) Si es el propietario del recurso O un administrador
         // En este punto, sabemos que el usuario puede continuar:
         next();

--- a/src/models/User.entity.js
+++ b/src/models/User.entity.js
@@ -1,5 +1,7 @@
 import mongoose from 'mongoose';
 import bcrypt from 'bcrypt';
+import { USER_ROLES } from '../config/const.js';
+
 
 // esquema de mongoose
 const usuarioSchema = new mongoose.Schema({
@@ -18,11 +20,26 @@ const usuarioSchema = new mongoose.Schema({
   password: {
     type: String,
     required: true,
-  }
+    select: false, //No se envía la contraseña en las consultas por defecto
+  },
+  //Rol para la autorización (RBAC)
+  rol: { 
+    type: String, 
+    enum: USER_ROLES, 
+    default: 'alumno',
+    required: true // El campo rol debe ser requerido para la autorización
+  }, 
+  //CAMPO AÑADIDO: Estado para el Borrado Lógico
+  estado: { 
+    type: String, 
+    enum: ['active', 'inactive'], 
+    default: 'active' 
+  }, 
   
 }, 
 {
   timestamps: true,
+  versionKey: false  //oculta el campo __V
 });
 
 //pre-save hook de mongoose mas seguridad al hashear las pass..


### PR DESCRIPTION
feat(rbac): Implementar autorización multi-rol para gestión de usuarios

Habilita el acceso de los roles 'admin' y 'secretaria' a las rutas de administración de usuarios, completando la lógica de Autorización Basada en Roles (RBAC) para este módulo.

Cambios clave:
- Actualiza `authorize.role.js` para aceptar arrays de roles (ej: ['admin', 'secretaria']).
- Modifica `authorize.user.js` para otorgar acceso de edición total al rol 'secretaria'.
- Aplica `authorizeRole(['admin', 'secretaria'])` a las rutas:
    - GET /users (Listado)
    - DELETE /users/:id (Borrado Lógico)